### PR TITLE
Fix health check timestamp

### DIFF
--- a/ddd_app_server/ddd_app_server/health.py
+++ b/ddd_app_server/ddd_app_server/health.py
@@ -7,7 +7,9 @@ def health_check(request):
         'message': 'healthy',
         'data': {
             'status': 'healthy',
-            'timestamp': datetime.datetime.now(datetime.timezone.utc).isoformat() + 'Z'
+            'timestamp': datetime.datetime.now(datetime.timezone.utc)
+                .isoformat()
+                .replace('+00:00', 'Z')
         }
     }
     return JsonResponse(response_data)


### PR DESCRIPTION
## Summary
- correct timestamp format in health check endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684053a7f110832c9d965fb4afbe1e14