### PR TITLE
Add direct profile fields and remove group logic

### DIFF
--- a/ddd_app_server/attendances/views.py
+++ b/ddd_app_server/attendances/views.py
@@ -93,7 +93,7 @@ class AttendanceListView(BaseResponseMixin, APIView):
 
             # Team 필터링
             if team_filter:
-                filtered_queryset = filtered_queryset.filter(user__groups__name=f"team:{team_filter}")
+                filtered_queryset = filtered_queryset.filter(user__profile__team=team_filter)
             
             # 날짜 필터링
             if start_date_filter:

--- a/ddd_app_server/profiles/admin.py
+++ b/ddd_app_server/profiles/admin.py
@@ -1,34 +1,14 @@
 from django.contrib import admin
 from .models import Profile
-from django.contrib.auth.models import Group
-import random
-
-@admin.action(description='Assign "cohort:12" to selected profiles')
-def assign_cohort_12(modeladmin, request, queryset):
-    cohort_group, created = Group.objects.get_or_create(name="cohort:12")
-    for profile in queryset:
-        profile.user.groups.add(cohort_group)
-
-@admin.action(description='Assign a random group to selected profiles')
-def assign_random_group(modeladmin, request, queryset):
-    role_gropus = Group.objects.filter(name__startswith="role:")
-    team_groups = Group.objects.filter(name__startswith="team:")
-    responsibility_groups = Group.objects.filter(name__startswith="responsibility:")
-    cohort_groups = Group.objects.filter(name__startswith="cohort:")
-    for profile in queryset:
-        random_role_group, _ = Group.objects.get_or_create(name=random.choice(role_gropus).name)
-        random_team_group, _ = Group.objects.get_or_create(name=random.choice(team_groups).name)
-        random_responsibility_group, _ = Group.objects.get_or_create(name=random.choice(responsibility_groups).name)
-        random_cohort_group, _ = Group.objects.get_or_create(name=random.choice(cohort_groups).name)
-        profile.user.groups.add(random_role_group)
-        profile.user.groups.add(random_team_group)
-        profile.user.groups.add(random_responsibility_group)
-        profile.user.groups.add(random_cohort_group)
 
 class ProfileAdmin(admin.ModelAdmin):
-    list_display = ('user_id', 'user', 'email', 'name', 'created_at')
-    search_fields = ('user__username', 'user__email', 'user__groups__name')
-    actions = [assign_cohort_12, assign_random_group]
+    list_display = (
+        'user_id', 'user', 'email', 'name', 'role', 'team', 'crew',
+        'responsibility', 'cohort', 'created_at'
+    )
+    search_fields = (
+        'user__username', 'user__email', 'role', 'team', 'crew', 'responsibility', 'cohort__name'
+    )
 
     @admin.display(description='User ID')
     def user_id(self, obj):

--- a/ddd_app_server/profiles/migrations/0005_profile_additional_fields.py
+++ b/ddd_app_server/profiles/migrations/0005_profile_additional_fields.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0004_remove_profile_cohort_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='profile',
+            name='role',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='profile',
+            name='team',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='profile',
+            name='crew',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='profile',
+            name='responsibility',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='profile',
+            name='cohort',
+            field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='profiles', to='profiles.cohort'),
+        ),
+    ]
+

--- a/ddd_app_server/profiles/models.py
+++ b/ddd_app_server/profiles/models.py
@@ -1,7 +1,6 @@
 import uuid
 from django.db import models
 from django.contrib.auth.models import User
-from django.utils import timezone
 from invites.models import InviteCode
 
 
@@ -9,6 +8,11 @@ class Profile(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
     name = models.CharField(max_length=255)
+    role = models.CharField(max_length=50, null=True, blank=True)
+    team = models.CharField(max_length=50, null=True, blank=True)
+    crew = models.CharField(max_length=50, null=True, blank=True)
+    responsibility = models.CharField(max_length=50, null=True, blank=True)
+    cohort = models.ForeignKey('Cohort', on_delete=models.SET_NULL, null=True, blank=True, related_name='profiles')
     invite_code = models.ForeignKey(InviteCode, on_delete=models.SET_NULL, null=True, blank=True, related_name='profiles')
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)


### PR DESCRIPTION
## Summary
- add team/role/crew/responsibility fields to `Profile`
- reintroduce `cohort` field
- generate migration for the new fields
- simplify `ProfileSerializer` to use model fields directly
- filter attendances via `Profile.team`
- clean up profile admin

## Testing
- `python ddd_app_server/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684064f1a728832ca4885fd7e194446b