### PR TITLE
Add request logging middleware

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -37,3 +37,7 @@ KAKAO_OAUTH_CALLBACK_URL=http://localhost:8000/accounts/kakao/login/callback/
 # Security Settings
 CORS_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 CSRF_TRUSTED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# Request Logging
+ENABLE_REQUEST_LOGGING=False
+REQUEST_LOG_FILE=/app/logs/request_logs.jsonl

--- a/ddd_app_server/common/management/__init__.py
+++ b/ddd_app_server/common/management/__init__.py
@@ -1,0 +1,1 @@
+"""Management commands for the common app."""

--- a/ddd_app_server/common/management/commands/__init__.py
+++ b/ddd_app_server/common/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Common management commands."""

--- a/ddd_app_server/common/management/commands/replay_requests.py
+++ b/ddd_app_server/common/management/commands/replay_requests.py
@@ -1,0 +1,51 @@
+import json
+import os
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.test import Client
+
+
+class Command(BaseCommand):
+    help = "Replay logged requests using Django's test client"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--file",
+            default=settings.REQUEST_LOG_FILE,
+            help="Path to request log file",
+        )
+
+    def handle(self, *args, **options):
+        file_path = options["file"]
+        if not os.path.exists(file_path):
+            self.stderr.write(f"File not found: {file_path}")
+            return
+
+        client = Client()
+        with open(file_path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                method = record.get("method", "get").lower()
+                path = record.get("path", "/")
+                params = record.get("query_params", {})
+                body = record.get("body")
+
+                url = path
+                if params:
+                    url = f"{path}?{urlencode(params)}"
+
+                http_method = getattr(client, method, None)
+                if not http_method:
+                    self.stderr.write(f"Unsupported method: {method}")
+                    continue
+
+                if body is not None and method in {"post", "put", "patch", "delete"}:
+                    response = http_method(url, data=json.dumps(body), content_type="application/json")
+                else:
+                    response = http_method(url)
+                self.stdout.write(f"{method.upper()} {url} -> {response.status_code}")

--- a/ddd_app_server/common/request_logging.py
+++ b/ddd_app_server/common/request_logging.py
@@ -1,0 +1,51 @@
+import json
+import os
+from django.conf import settings
+
+
+class RequestLoggingMiddleware:
+    """Middleware that logs incoming HTTP requests."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.enabled = getattr(settings, "ENABLE_REQUEST_LOGGING", False)
+        self.log_file = getattr(
+            settings,
+            "REQUEST_LOG_FILE",
+            os.path.join(settings.BASE_DIR, "logs", "request_logs.jsonl"),
+        )
+        if self.enabled:
+            log_dir = os.path.dirname(self.log_file)
+            if log_dir and not os.path.exists(log_dir):
+                os.makedirs(log_dir, exist_ok=True)
+
+    def __call__(self, request):
+        if self.enabled:
+            self.log_request(request)
+        response = self.get_response(request)
+        return response
+
+    def log_request(self, request):
+        data = {
+            "method": request.method,
+            "path": request.path,
+            "headers": {k: v for k, v in request.headers.items()},
+            "query_params": request.GET.dict(),
+            "body": self.get_body(request),
+        }
+        try:
+            with open(self.log_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(data, ensure_ascii=False) + "\n")
+        except Exception:
+            pass
+
+    def get_body(self, request):
+        if not request.body:
+            return None
+        try:
+            return json.loads(request.body.decode("utf-8"))
+        except Exception:
+            try:
+                return request.body.decode("utf-8")
+            except Exception:
+                return str(request.body)

--- a/ddd_app_server/ddd_app_server/settings/base.py
+++ b/ddd_app_server/ddd_app_server/settings/base.py
@@ -24,6 +24,13 @@ load_dotenv()
 # Build paths inside the project
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+# Request logging settings
+ENABLE_REQUEST_LOGGING = os.getenv("ENABLE_REQUEST_LOGGING", "False").lower() == "true"
+REQUEST_LOG_FILE = os.getenv(
+    "REQUEST_LOG_FILE",
+    str(BASE_DIR / "logs" / "request_logs.jsonl"),
+)
+
 # Application definition
 INSTALLED_APPS = [
     'django.contrib.admin',
@@ -73,6 +80,9 @@ MIDDLEWARE = [
     'allauth.account.middleware.AccountMiddleware',
     'common.middleware.StandardizedErrorMiddleware',
 ]
+
+if ENABLE_REQUEST_LOGGING:
+    MIDDLEWARE.append('common.request_logging.RequestLoggingMiddleware')
 
 ROOT_URLCONF = 'ddd_app_server.urls'
 


### PR DESCRIPTION
## Summary
- implement `RequestLoggingMiddleware` for debugging
- add environment variables to toggle request logging
- enable optional replay management command
- document the new vars in `.env.template`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `DJANGO_SETTINGS_MODULE=ddd_app_server.settings.local SECRET_KEY=dummy DATABASE_URL=sqlite:///db.sqlite3 python ddd_app_server/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840665ae744832ca464076dd9b61b21