### PR TITLE
Implement profile creation endpoint

### DIFF
--- a/ddd_app_server/profiles/tests.py
+++ b/ddd_app_server/profiles/tests.py
@@ -1,3 +1,26 @@
 from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from django.contrib.auth import get_user_model
+from profiles.models import Profile
 
-# Create your tests here.
+User = get_user_model()
+
+
+class ProfileCreationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_create_profile_creates_user_and_profile(self):
+        data = {
+            "email": "newuser@example.com",
+            "password": "pass1234",
+            "name": "New User",
+        }
+        url = reverse("profile-create")
+        response = self.client.post(url, data, format="json")
+        self.assertEqual(response.status_code, 201)
+        self.assertTrue(User.objects.filter(email="newuser@example.com").exists())
+        self.assertTrue(
+            Profile.objects.filter(user__email="newuser@example.com").exists()
+        )

--- a/ddd_app_server/profiles/urls.py
+++ b/ddd_app_server/profiles/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path, re_path
-from .views import ProfileDetailView
+from .views import ProfileDetailView, ProfileCreateView
 
 # prefix = "profiles/"
 urlpatterns = [
     # Profile endpoints
-    path('me/', ProfileDetailView.as_view(), name='profile-detail-me'),
-    path('<uuid:profile_id>/', ProfileDetailView.as_view(), name='profile-detail'),
+    path("", ProfileCreateView.as_view(), name="profile-create"),
+    path("me/", ProfileDetailView.as_view(), name="profile-detail-me"),
+    path("<uuid:profile_id>/", ProfileDetailView.as_view(), name="profile-detail"),
     # re_path(r'^(?P<profile_id>(me|[0-9a-f-]{36}))/$', ProfileDetailView.as_view(), name='profile-detail'),
 ]

--- a/ddd_app_server/profiles/views.py
+++ b/ddd_app_server/profiles/views.py
@@ -10,11 +10,19 @@ from .serializers import ProfileSerializer
 
 logger = logging.getLogger(__name__)
 
+
 # 프로필 조회 성공 응답 Serializer
 class ProfileSuccesSerializer(serializers.Serializer):
     code = serializers.IntegerField(default=200)
     message = serializers.CharField(default="프로필 조회에 성공했습니다.")
     data = ProfileSerializer()
+
+
+class ProfileCreateSuccessSerializer(serializers.Serializer):
+    code = serializers.IntegerField(default=201)
+    message = serializers.CharField(default="프로필이 성공적으로 생성되었습니다.")
+    data = ProfileSerializer()
+
 
 # 특정 사용자 프로필 조회 APIView
 class ProfileDetailView(BaseResponseMixin, CurrentProfileMixin, APIView):
@@ -25,45 +33,84 @@ class ProfileDetailView(BaseResponseMixin, CurrentProfileMixin, APIView):
         tags=["profiles"],
         operation_summary="프로필 조회",
         operation_description="프로필 정보를 조회합니다.",
-        responses={
-            200: ProfileSuccesSerializer,
-            400: ErrorResponseSerializer
-        },
+        responses={200: ProfileSuccesSerializer, 400: ErrorResponseSerializer},
     )
     def get(self, request, *args, **kwargs):
-        profile_id = self.kwargs.get('profile_id')
+        profile_id = self.kwargs.get("profile_id")
         profile = self.get_profile(profile_id)
         serializer = ProfileSerializer(profile)
-        return self.create_response(200, "프로필 정보를 성공적으로 조회했습니다.", serializer.data)
+        return self.create_response(
+            200, "프로필 정보를 성공적으로 조회했습니다.", serializer.data
+        )
 
     @swagger_auto_schema(
         tags=["profiles"],
         operation_summary="프로필 수정",
         operation_description="프로필 정보를 부분 업데이트합니다.",
         request_body=ProfileSerializer,
-        responses={
-            200: ProfileSuccesSerializer,
-            400: ErrorResponseSerializer
-        },
+        responses={200: ProfileSuccesSerializer, 400: ErrorResponseSerializer},
     )
     def patch(self, request, *args, **kwargs):
-        profile_id = self.kwargs.get('profile_id')
+        profile_id = self.kwargs.get("profile_id")
         profile = self.get_profile(profile_id)
 
-
         # Permission Check: Is the requester the owner or staff?
-        is_owner = (profile.user == request.user)
-        is_staff = (request.user.is_staff or request.user.groups.filter(name="moderator").exists())
+        is_owner = profile.user == request.user
+        is_staff = (
+            request.user.is_staff
+            or request.user.groups.filter(name="moderator").exists()
+        )
 
         # Check if the user is the owner or a moderator
         if not (is_owner or is_staff):
-            return self.create_response(403, "프로필을 수정할 권한이 없습니다.", {}, status.HTTP_403_FORBIDDEN)
+            return self.create_response(
+                403, "프로필을 수정할 권한이 없습니다.", {}, status.HTTP_403_FORBIDDEN
+            )
 
-        serializer = ProfileSerializer(profile, data=request.data, context={'request': request}, partial=True)
+        serializer = ProfileSerializer(
+            profile, data=request.data, context={"request": request}, partial=True
+        )
         if serializer.is_valid():
             serializer.save()
-            return self.create_response(200, "프로필이 성공적으로 수정되었습니다.", serializer.data)
+            return self.create_response(
+                200, "프로필이 성공적으로 수정되었습니다.", serializer.data
+            )
         else:
             logger.error(f"Serializer errors: {serializer.errors}")
-            return self.create_response(400, "프로필 수정에 실패했습니다.", serializer.errors, status.HTTP_400_BAD_REQUEST)
+            return self.create_response(
+                400,
+                "프로필 수정에 실패했습니다.",
+                serializer.errors,
+                status.HTTP_400_BAD_REQUEST,
+            )
 
+
+class ProfileCreateView(BaseResponseMixin, APIView):
+    permission_classes = [permissions.AllowAny]
+
+    @swagger_auto_schema(
+        tags=["profiles"],
+        operation_summary="프로필 생성",
+        operation_description="새로운 프로필을 생성합니다.",
+        request_body=ProfileSerializer,
+        responses={
+            201: ProfileCreateSuccessSerializer,
+            400: ErrorResponseSerializer,
+        },
+    )
+    def post(self, request, *args, **kwargs):
+        serializer = ProfileSerializer(data=request.data)
+        if serializer.is_valid():
+            profile = serializer.save()
+            return self.create_response(
+                201,
+                "프로필이 성공적으로 생성되었습니다.",
+                ProfileSerializer(profile).data,
+                status.HTTP_201_CREATED,
+            )
+        return self.create_response(
+            400,
+            "프로필 생성에 실패했습니다.",
+            serializer.errors,
+            status.HTTP_400_BAD_REQUEST,
+        )

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -107,6 +107,41 @@
       },
       "parameters": []
     },
+    "/api/v1/profiles/": {
+      "post": {
+        "operationId": "api_v1_profiles_create",
+        "summary": "프로필 생성",
+        "description": "새로운 프로필을 생성합니다.",
+        "parameters": [
+          {
+            "name": "data",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Profile"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Profile"
+            }
+          },
+          "400": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "tags": [
+          "profiles"
+        ]
+      },
+      "parameters": []
+    },
     "/api/v1/profiles/me/": {
       "get": {
         "operationId": "api_v1_profiles_me_list",
@@ -954,6 +989,16 @@
         },
         "user": {
           "$ref": "#/definitions/User"
+        },
+        "email": {
+          "title": "Email",
+          "type": "string",
+          "format": "email"
+        },
+        "password": {
+          "title": "Password",
+          "type": "string",
+          "x-nullable": true
         },
         "name": {
           "title": "Name",


### PR DESCRIPTION
## Summary
- extend ProfileSerializer with email and password fields
- create users & profiles in serializer `create()` method
- add ProfileCreateView and route
- expose new POST endpoint in OpenAPI schema
- test that posting profile data creates user and profile

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684065aa8ecc832c8179c51dc6466d12