### PR TITLE
Add request logging middleware

### DIFF
--- a/ddd_app_server/ddd_app_server/settings/local.py
+++ b/ddd_app_server/ddd_app_server/settings/local.py
@@ -96,6 +96,12 @@ LOGGING = {
             'filename': '/app/logs/django_general.log',
             'formatter': 'verbose',
         },
+        'file_access': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': '/app/logs/django_access.log',
+            'formatter': 'verbose',
+        },
         'file_errors_detail': {
             'level': 'DEBUG',
             'class': 'logging.FileHandler',
@@ -117,6 +123,11 @@ LOGGING = {
         'standardized_error': {
             'handlers': ['console', 'file_errors_detail'],
             'level': 'DEBUG',
+            'propagate': False,
+        },
+        'common.request_logging': {
+            'handlers': ['console', 'file_access'],
+            'level': 'INFO',
             'propagate': False,
         },
         '': {  # Root logger

--- a/ddd_app_server/ddd_app_server/settings/production.py
+++ b/ddd_app_server/ddd_app_server/settings/production.py
@@ -95,6 +95,12 @@ LOGGING = {
             'filename': '/app/logs/django_general.log',
             'formatter': 'verbose',
         },
+        'file_access': {
+            'level': 'INFO',
+            'class': 'logging.FileHandler',
+            'filename': '/app/logs/django_access.log',
+            'formatter': 'verbose',
+        },
     },
     'loggers': {
         'django': {
@@ -105,6 +111,11 @@ LOGGING = {
         'django.request': {
             'handlers': ['console', 'file_errors'],
             'level': 'ERROR',
+            'propagate': False,
+        },
+        'common.request_logging': {
+            'handlers': ['console', 'file_access'],
+            'level': 'INFO',
             'propagate': False,
         },
         '': {  # Root logger


### PR DESCRIPTION
## Summary
- integrate RequestLoggingMiddleware for request tracing
- configure dedicated access loggers in local and production settings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841c794e178832caa67839f24ffb59c